### PR TITLE
Move React frontend into src/front_end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # DemoPortal
+
+This demo project provides a basic React page built with Tailwind CSS and shadcn/ui-style components. It lists API documentation items and shows a floating chat window placeholder.
+
+## Getting Started
+
+Install dependencies (if your environment allows network access) from the
+`src/front_end` directory:
+
+```bash
+cd src/front_end
+npm install
+```
+
+Start the development server from the same directory:
+
+```bash
+npm start
+```
+
+Then open `http://localhost:3000` in your browser.

--- a/src/front_end/package.json
+++ b/src/front_end/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "demoportal",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/src/front_end/public/index.html
+++ b/src/front_end/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DemoPortal</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet" />
+</head>
+<body class="bg-gray-50">
+  <div id="root"></div>
+  <script type="text/babel" src="../src/index.jsx"></script>
+</body>
+</html>

--- a/src/front_end/server.js
+++ b/src/front_end/server.js
@@ -1,0 +1,25 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+
+const server = createServer(async (req, res) => {
+  let filePath = 'public' + (req.url === '/' ? '/index.html' : req.url);
+  try {
+    const data = await readFile(filePath);
+    const ext = extname(filePath);
+    const types = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css',
+    };
+    res.writeHead(200, { 'Content-Type': types[ext] || 'text/plain' });
+    res.end(data);
+  } catch {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Server running at http://localhost:3000');
+});

--- a/src/front_end/src/App.jsx
+++ b/src/front_end/src/App.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ApiList from './components/ApiList';
+import ChatWindow from './components/ChatWindow';
+
+export default function App() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">API Documentation</h1>
+      <ApiList />
+      <ChatWindow />
+    </div>
+  );
+}

--- a/src/front_end/src/components/ApiList.jsx
+++ b/src/front_end/src/components/ApiList.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { apiData } from '../data/apis';
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+
+export default function ApiList() {
+  return (
+    <div className="space-y-4">
+      {apiData.apis.map((api) => (
+        <Card key={api.id}>
+          <CardHeader>
+            <CardTitle>{api.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-gray-600 mb-2">{api.description}</p>
+            <p className="font-mono text-sm">
+              <span className="font-semibold">{api.method}</span> {api.endpoint}
+            </p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function ChatWindow() {
+  const [open, setOpen] = React.useState(true);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 w-72 bg-white border rounded shadow-lg flex flex-col">
+      <div className="flex justify-between items-center border-b p-2">
+        <span className="font-semibold">Chat</span>
+        <button className="text-gray-400 hover:text-gray-600" onClick={() => setOpen(false)}>✕</button>
+      </div>
+      <div className="p-2 overflow-y-auto" style={{ maxHeight: '300px' }}>
+        <p className="text-sm text-gray-500">Chat content coming soon...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/front_end/src/components/ui/card.jsx
+++ b/src/front_end/src/components/ui/card.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export function Card({ className = '', ...props }) {
+  return <div className={`rounded-lg border bg-white shadow ${className}`} {...props} />;
+}
+
+export function CardHeader({ className = '', ...props }) {
+  return <div className={`border-b px-4 py-2 ${className}`} {...props} />;
+}
+
+export function CardTitle({ className = '', ...props }) {
+  return <h3 className={`text-lg font-semibold ${className}`} {...props} />;
+}
+
+export function CardContent({ className = '', ...props }) {
+  return <div className={`p-4 ${className}`} {...props} />;
+}

--- a/src/front_end/src/data/apis.js
+++ b/src/front_end/src/data/apis.js
@@ -1,0 +1,11 @@
+export const apiData = {
+  apis: [
+    {
+      id: 'user-auth',
+      name: 'User Authentication API',
+      description: 'Used for user login and authentication.',
+      endpoint: '/api/v1/auth',
+      method: 'POST',
+    },
+  ],
+};

--- a/src/front_end/src/index.jsx
+++ b/src/front_end/src/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- move the entire frontend (package.json, static server, React source) under `src/front_end`
- update README with new path instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685693fe58b883269a06840a98e2f3e6