### PR TITLE
Implement WebSocket server with python-socketio

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,11 @@ The backend uses FastAPI. To run it locally:
 cd backend
 uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 ```
+
+### Running Tests
+
+Execute the WebSocket unit tests with:
+
+```bash
+pytest tests/test_websocket.py
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,18 @@
 import logging
 from fastapi import FastAPI
 from routers import api
+from sockets.websocket import socket_app
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Dev Portal API")
 
-# Include routers from routers/api.py
+# Include routers
 app.include_router(api.router)
 
+# Mount the socket.io ASGI app
+app.mount("/", socket_app)
+
 logger.info("Application startup complete")
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,7 @@
 fastapi
-uvicorn
+uvicorn[standard]
+python-socketio
+aiohttp
+
+pytest
+pytest-asyncio

--- a/backend/sockets/websocket.py
+++ b/backend/sockets/websocket.py
@@ -1,0 +1,24 @@
+import socketio
+
+# Setup Async WebSocket server
+sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
+
+# ASGI application to mount in FastAPI
+socket_app = socketio.ASGIApp(sio)
+
+@sio.event
+async def connect(sid, environ):
+    print(f'Client connected: {sid}')
+
+@sio.event
+async def disconnect(sid):
+    print(f'Client disconnected: {sid}')
+
+@sio.event
+async def user_message(sid, data):
+    print(f'Received message from {sid}: {data}')
+    response = {
+        "responseText": "Here is the curl example command for the User Authentication API:\n\ncurl -X POST https://example.com/api/v1/auth -H 'Content-Type: application/json' -d '{\"username\": \"your_username\", \"password\": \"your_password\"}'",
+        "highlightSelector": "#user-auth-api-section"
+    }
+    await sio.emit('bot_response', response, room=sid)

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -1,0 +1,69 @@
+import asyncio
+import os
+import sys
+import threading
+import time
+
+import pytest
+import socketio
+import uvicorn
+
+# Add the backend directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from main import app
+
+
+@pytest.fixture(scope="module")
+def start_server():
+    """Start the FastAPI + Socket.IO server in a background thread."""
+    config = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="warning", lifespan="off")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    # Give the server a moment to start
+    time.sleep(0.5)
+    yield
+    server.should_exit = True
+    thread.join()
+
+
+@pytest.mark.asyncio
+async def test_websocket_connection(start_server):
+    sio = socketio.AsyncClient()
+    await sio.connect("http://127.0.0.1:8000", transports=["websocket"])
+    assert sio.connected
+    await sio.disconnect()
+    assert not sio.connected
+
+
+@pytest.mark.asyncio
+async def test_websocket_user_message(start_server):
+    sio = socketio.AsyncClient()
+    received = []
+
+    @sio.event
+    async def bot_response(data):
+        received.append(data)
+
+    await sio.connect("http://127.0.0.1:8000", transports=["websocket"])
+    assert sio.connected
+
+    test_message = {
+        "context": {
+            "currentPage": "User Authentication API",
+            "selectedLanguage": "curl",
+            "previousQueries": ["What APIs do we have?"]
+        },
+        "userQuery": "Give me a request example for the User Authentication API"
+    }
+    await sio.emit("user_message", test_message)
+
+    await asyncio.sleep(1)
+
+    assert len(received) == 1
+    response = received[0]
+    assert response.get("highlightSelector") == "#user-auth-api-section"
+    assert "curl -X POST" in response.get("responseText", "")
+
+    await sio.disconnect()
+    assert not sio.connected


### PR DESCRIPTION
## Summary
- set up socket.io server in `sockets/websocket.py`
- mount socket.io ASGI app in FastAPI `main.py`
- add python-socketio and uvicorn[standard] to backend requirements
- add pytest and aiohttp to requirements
- write pytest tests for the websocket server
- document how to run backend tests

## Testing
- `python -m compileall backend`
- `pip install -r backend/requirements.txt`
- `pytest backend/tests/test_websocket.py`

------
https://chatgpt.com/codex/tasks/task_e_6856a2dd9d508326b3c0f1c1e164a3b0