### PR TITLE
Integrate GPT-4 with websocket backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.log
 __pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The chat window can now highlight sections of the page when the backend sends a
 `highlightSelector` over the WebSocket connection. Highlighted elements briefly
 animate with a yellow ring to draw attention to relevant documentation.
 
+The backend integrates with the OpenAI GPT-4 API to generate example `curl`
+commands in response to chat messages. Provide your API key in a `.env` file
+based on `backend/.env.example` when running locally.
+
 ## Getting Started
 
 Install dependencies (if your environment allows network access) from the

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key_here

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,9 +2,13 @@ import logging
 from fastapi import FastAPI
 from routers import api
 from sockets.websocket import socket_app
+from dotenv import load_dotenv
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Load environment variables from .env file if present
+load_dotenv()
 
 app = FastAPI(title="Dev Portal API")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,5 +3,8 @@ uvicorn[standard]
 python-socketio
 aiohttp
 
+openai
+python-dotenv
+
 pytest
 pytest-asyncio

--- a/backend/services/gpt_service.py
+++ b/backend/services/gpt_service.py
@@ -1,0 +1,28 @@
+import os
+from typing import Dict
+
+import openai
+from openai import OpenAIError
+
+# API key loaded from environment
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+async def generate_curl_example(context: Dict, user_query: str) -> str:
+    """Generate a curl command example using GPT-4 based on the given context and user query."""
+    prompt = (
+        "Given the following context and user query, generate a well-formatted curl example:\n\n"
+        f"Context: {context}\n"
+        f"User query: {user_query}\n\n"
+        "Curl example:"
+    )
+    try:
+        response = await openai.ChatCompletion.acreate(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+            max_tokens=300,
+        )
+        return response.choices[0].message.content.strip()
+    except OpenAIError as exc:
+        # Return an error message that can be displayed to the user
+        return f"Error generating example: {exc}"

--- a/backend/sockets/websocket.py
+++ b/backend/sockets/websocket.py
@@ -1,5 +1,7 @@
 import socketio
 
+from services.gpt_service import generate_curl_example
+
 # Setup Async WebSocket server
 sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
 
@@ -17,8 +19,14 @@ async def disconnect(sid):
 @sio.event
 async def user_message(sid, data):
     print(f'Received message from {sid}: {data}')
+    context = data.get("context", {})
+    user_query = data.get("userQuery", "")
+
+    curl_example = await generate_curl_example(context, user_query)
+
     response = {
-        "responseText": "Here is the curl example command for the User Authentication API:\n\ncurl -X POST https://example.com/api/v1/auth -H 'Content-Type: application/json' -d '{\"username\": \"your_username\", \"password\": \"your_password\"}'",
-        "highlightSelector": "#user-auth-api-section"
+        "responseText": curl_example,
+        "highlightSelector": "#user-auth-api-section",
     }
-    await sio.emit('bot_response', response, room=sid)
+
+    await sio.emit("bot_response", response, room=sid)

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -11,6 +11,8 @@ import uvicorn
 # Add the backend directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from main import app
+from services import gpt_service
+from sockets import websocket
 
 
 @pytest.fixture(scope="module")
@@ -37,9 +39,15 @@ async def test_websocket_connection(start_server):
 
 
 @pytest.mark.asyncio
-async def test_websocket_user_message(start_server):
+async def test_websocket_user_message(start_server, monkeypatch):
     sio = socketio.AsyncClient()
     received = []
+
+    async def fake_generate_curl_example(context, user_query):
+        return "curl -X POST https://example.com/api/v1/auth -d '{\"user\":\"test\"}'"
+
+    monkeypatch.setattr(gpt_service, "generate_curl_example", fake_generate_curl_example)
+    monkeypatch.setattr(websocket, "generate_curl_example", fake_generate_curl_example)
 
     @sio.event
     async def bot_response(data):


### PR DESCRIPTION
## Summary
- load environment variables at startup
- add GPT service to call OpenAI API
- update websocket handler to generate curl examples via GPT
- ignore local `.env` and add example env file
- expand backend requirements
- update README with GPT mention
- patch tests to mock GPT service

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a59b9dc08326afbe966a18188358