### PR TITLE
Fix server to load React src files

### DIFF
--- a/src/front_end/server.js
+++ b/src/front_end/server.js
@@ -1,9 +1,14 @@
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { extname } from 'node:path';
+import { extname, join } from 'node:path';
 
 const server = createServer(async (req, res) => {
-  let filePath = 'public' + (req.url === '/' ? '/index.html' : req.url);
+  let filePath;
+  if (req.url.startsWith('/src/')) {
+    filePath = join('src', req.url.slice('/src/'.length));
+  } else {
+    filePath = join('public', req.url === '/' ? 'index.html' : req.url);
+  }
   try {
     const data = await readFile(filePath);
     const ext = extname(filePath);
@@ -11,6 +16,7 @@ const server = createServer(async (req, res) => {
       '.html': 'text/html',
       '.js': 'text/javascript',
       '.css': 'text/css',
+      '.jsx': 'text/jsx',
     };
     res.writeHead(200, { 'Content-Type': types[ext] || 'text/plain' });
     res.end(data);


### PR DESCRIPTION
## Summary
- serve JS files from the `src` folder so the browser can load `src/index.jsx`

## Testing
- `npm test` in `src/front_end`
- `pytest tests/test_websocket.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e6000fac83268c9e04886d194183