### PR TITLE
Fix CSP error for Babel runtime

### DIFF
--- a/src/front_end/public/index.html
+++ b/src/front_end/public/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Allow inline Babel compilation -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval'">
   <title>DemoPortal</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>


### PR DESCRIPTION
## Summary
- allow `unsafe-eval` so Babel runtime compilation works when the site enforces a CSP

## Testing
- `pytest backend/tests/test_websocket.py` *(fails: ModuleNotFoundError: No module named 'socketio')*

------
https://chatgpt.com/codex/tasks/task_e_6856eb069a00832683071936793b684b