### PR TITLE
Fix inline script CSP issue

### DIFF
--- a/src/front_end/public/index.html
+++ b/src/front_end/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Allow inline Babel compilation -->
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' https://unpkg.com">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline' https://unpkg.com">
   <title>DemoPortal</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>


### PR DESCRIPTION
## Summary
- adjust CSP meta tag to allow inline scripts so that dev environment doesn't throw errors

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests/test_websocket.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6856ed2248188326868d28573f67ea04