### PR TITLE
Fix React page not loading

### DIFF
--- a/src/front_end/public/index.html
+++ b/src/front_end/public/index.html
@@ -15,6 +15,6 @@
 </head>
 <body class="bg-gray-50">
   <div id="root"></div>
-  <script type="text/babel" src="../src/index.jsx"></script>
+  <script type="text/babel" data-type="module" src="../src/index.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix blank page by telling Babel to compile modules in `index.html`

## Testing
- `npm test`
- `pytest tests/test_websocket.py`

------
https://chatgpt.com/codex/tasks/task_e_6856f079c7b08326b824bfb110d5b147