### PR TITLE
Fix React import error in browser

### DIFF
--- a/src/front_end/src/App.jsx
+++ b/src/front_end/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ApiList from './components/ApiList';
 import ChatWindow from './components/ChatWindow';
 

--- a/src/front_end/src/SocketProvider.jsx
+++ b/src/front_end/src/SocketProvider.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+const { createContext, useContext, useEffect, useRef, useState } = React;
 
 // the global `io` is loaded from socket.io.min.js
 const SocketContext = createContext(null);

--- a/src/front_end/src/components/ApiList.jsx
+++ b/src/front_end/src/components/ApiList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { apiData } from '../data/apis';
 import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
 

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MessageCircle, Minus } from 'lucide-react';
 import { useSocket } from '../SocketProvider.jsx';
 import { useElementHighlight } from '../hooks/useElementHighlight.js';

--- a/src/front_end/src/components/ui/card.jsx
+++ b/src/front_end/src/components/ui/card.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export function Card({ className = '', ...props }) {
   return <div className={`rounded-lg border bg-white shadow ${className}`} {...props} />;

--- a/src/front_end/src/hooks/useElementHighlight.js
+++ b/src/front_end/src/hooks/useElementHighlight.js
@@ -1,5 +1,5 @@
 import { animate } from 'framer-motion';
-import { useCallback, useEffect, useRef } from 'react';
+const { useCallback, useEffect, useRef } = React;
 
 export function useElementHighlight(duration = 3000) {
   const timerRef = useRef(null);

--- a/src/front_end/src/index.jsx
+++ b/src/front_end/src/index.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
 import App from './App';
 import { SocketProvider } from './SocketProvider.jsx';
 


### PR DESCRIPTION
## Summary
- remove `import React` statements and rely on global React
- adapt hooks and context provider accordingly

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f178caf88326a0e8da18b5bf38e1