### PR TITLE
Fix module paths for browser imports

### DIFF
--- a/src/front_end/src/App.jsx
+++ b/src/front_end/src/App.jsx
@@ -1,5 +1,5 @@
-import ApiList from './components/ApiList';
-import ChatWindow from './components/ChatWindow';
+import ApiList from '/src/components/ApiList.jsx';
+import ChatWindow from '/src/components/ChatWindow.jsx';
 
 export default function App() {
   return (

--- a/src/front_end/src/components/ApiList.jsx
+++ b/src/front_end/src/components/ApiList.jsx
@@ -1,5 +1,5 @@
-import { apiData } from '../data/apis';
-import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
+import { apiData } from '/src/data/apis.js';
+import { Card, CardHeader, CardTitle, CardContent } from '/src/components/ui/card.jsx';
 
 export default function ApiList() {
   return (

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -1,6 +1,6 @@
 import { MessageCircle, Minus } from 'lucide-react';
-import { useSocket } from '../SocketProvider.jsx';
-import { useElementHighlight } from '../hooks/useElementHighlight.js';
+import { useSocket } from '/src/SocketProvider.jsx';
+import { useElementHighlight } from '/src/hooks/useElementHighlight.js';
 
 export default function ChatWindow() {
   const [open, setOpen] = React.useState(true);

--- a/src/front_end/src/index.jsx
+++ b/src/front_end/src/index.jsx
@@ -1,5 +1,5 @@
-import App from './App';
-import { SocketProvider } from './SocketProvider.jsx';
+import App from '/src/App.jsx';
+import { SocketProvider } from '/src/SocketProvider.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- use absolute `/src/...` imports so the demo server resolves files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f2ff104c8326897334770749123c