### PR TITLE
Fix MIME type for JSX files

### DIFF
--- a/src/front_end/server.js
+++ b/src/front_end/server.js
@@ -16,7 +16,8 @@ const server = createServer(async (req, res) => {
       '.html': 'text/html',
       '.js': 'text/javascript',
       '.css': 'text/css',
-      '.jsx': 'text/jsx',
+      // Serve JSX with a JavaScript MIME type so module scripts load correctly
+      '.jsx': 'text/javascript',
     };
     res.writeHead(200, { 'Content-Type': types[ext] || 'text/plain' });
     res.end(data);


### PR DESCRIPTION
## Summary
- ensure server serves `.jsx` files with a JavaScript MIME type so browsers load them correctly

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f414778c83269f787a8d6398a086