### PR TITLE
Fix lucide-react import error

### DIFF
--- a/src/front_end/package-lock.json
+++ b/src/front_end/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/core": "^7.27.4",
         "@babel/preset-react": "^7.27.1",
         "framer-motion": "^12.18.1",
-        "lucide-react": "^0.522.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "socket.io-client": "^4.7.2"
@@ -4620,15 +4619,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/lucide-react": {
-      "version": "0.522.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.522.0.tgz",
-      "integrity": "sha512-jnJbw974yZ7rQHHEFKJOlWAefG3ATSCZHANZxIdx8Rk/16siuwjgA4fBULpXEAWx/RlTs3FzmKW/udWUuO0aRw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/src/front_end/package.json
+++ b/src/front_end/package.json
@@ -15,7 +15,6 @@
     "@babel/core": "^7.27.4",
     "@babel/preset-react": "^7.27.1",
     "framer-motion": "^12.18.1",
-    "lucide-react": "^0.522.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "socket.io-client": "^4.7.2"

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -1,4 +1,40 @@
-import { MessageCircle, Minus } from 'lucide-react';
+function MessageCircleIcon(props) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-message-circle"
+    >
+      <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
+    </svg>
+  );
+}
+
+function MinusIcon(props) {
+  return (
+    <svg
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="lucide lucide-minus"
+    >
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
 import { useSocket } from '/src/SocketProvider.jsx';
 import { useElementHighlight } from '/src/hooks/useElementHighlight.js';
 
@@ -54,7 +90,7 @@ export default function ChatWindow() {
             className="text-gray-400 hover:text-gray-600"
             onClick={() => setOpen(false)}
           >
-            <Minus size={16} />
+            <MinusIcon width={16} height={16} />
           </button>
         </div>
         <div ref={messagesRef} className="p-2 overflow-y-auto space-y-2 flex-1" style={{ maxHeight: '300px' }}>
@@ -88,7 +124,7 @@ export default function ChatWindow() {
           className="fixed bottom-4 right-4 p-3 rounded-full bg-blue-600 text-white shadow-lg hover:bg-blue-700 transition"
           onClick={() => setOpen(true)}
         >
-          <MessageCircle size={20} />
+          <MessageCircleIcon width={20} height={20} />
         </button>
       )}
     </>

--- a/src/front_end/src/hooks/useElementHighlight.js
+++ b/src/front_end/src/hooks/useElementHighlight.js
@@ -1,5 +1,5 @@
+import React, { useCallback, useEffect, useRef } from 'react';
 import { animate } from 'framer-motion';
-const { useCallback, useEffect, useRef } = React;
 
 export function useElementHighlight(duration = 3000) {
   const timerRef = useRef(null);


### PR DESCRIPTION
## Summary
- remove lucide-react as a dependency
- inline simple SVG icons for chat window
- import React hooks directly in useElementHighlight

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856f6c2c2fc8326a3c2cd2fdd0f6d0e