### PR TITLE
Add fastmcp chat integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+LLM_BASE_URL=https://api.openai.com/v1
+LLM_API_KEY=your_llm_api_key
+LLM_MODEL=gpt-4o-mini

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import logging
 from fastapi import FastAPI
-from routers import api
+from routers import api, chat
+from services.mcp_client import mcp_server
 from sockets.websocket import socket_app
 from dotenv import load_dotenv
 
@@ -14,9 +15,11 @@ app = FastAPI(title="Dev Portal API")
 
 # Include routers
 app.include_router(api.router)
+app.include_router(chat.router)
 
 # Mount the socket.io ASGI app
 app.mount("/", socket_app)
+app.mount("/mcp", mcp_server.http_app())
 
 logger.info("Application startup complete")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]
 python-socketio
 aiohttp
 
+fastmcp>=0.5.0
 mcp[cli]
 python-dotenv
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import api, chat
+
+__all__ = ["api", "chat"]

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from services.mcp_client import mcp_client
+
+router = APIRouter()
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    message: str
+
+
+@router.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest) -> ChatResponse:
+    completion = await mcp_client.complete({}, req.message)
+    return ChatResponse(message=completion.text)

--- a/backend/services/mcp_client.py
+++ b/backend/services/mcp_client.py
@@ -1,12 +1,102 @@
-try:
-    from mcp.server.fastmcp import FastMCP
-except ModuleNotFoundError:  # older SDK fallback for tests
-    class FastMCP:
-        def __init__(self, *args, **kwargs):
-            pass
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
-        async def complete(self, *args, **kwargs):
-            raise NotImplementedError("FastMCPClient not available")
+import fastmcp
+from fastmcp import Client, FastMCP
 
-# Initializes MCP client with a unique name
-mcp_client = FastMCP(name="DevPortalClient")
+# --- MCP server setup with built-in tools ---------------------------------
+
+APIS = [
+    {
+        "name": "listUsers",
+        "path": "/api/users",
+        "method": "GET",
+        "description": "List all users",
+    },
+    {
+        "name": "getUser",
+        "path": "/api/users/{id}",
+        "method": "GET",
+        "description": "Get a specific user",
+    },
+]
+
+mcp_server = FastMCP(name="DevPortalServer")
+
+
+@mcp_server.tool(name="list_apis")
+def list_apis() -> List[Dict[str, str]]:
+    """Return a list of available HTTP APIs."""
+    return APIS
+
+
+@mcp_server.tool(name="get_api_sample")
+def get_api_sample(api_name: str) -> str:
+    """Return a curl example for the given API name."""
+    for api in APIS:
+        if api_name.lower() == api["name"].lower():
+            return f"curl -X {api['method']} http://localhost:8000{api['path']}"
+    raise ValueError(f"API '{api_name}' not found")
+
+
+# --- LLM chat helper ------------------------------------------------------
+
+async def llm_chat(messages: List[Dict[str, Any]], *, tools: List[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Send chat messages to an OpenAI-compatible endpoint."""
+    import httpx
+
+    base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1").rstrip("/")
+    api_key = os.getenv("LLM_API_KEY", "")
+    model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+
+    payload: Dict[str, Any] = {"model": model, "messages": messages}
+    if tools:
+        payload["tools"] = tools
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/chat/completions", json=payload, headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# --- MCP client wrapper ---------------------------------------------------
+
+@dataclass
+class Completion:
+    text: str
+    highlight_selector: str | None = None
+
+
+class MCPClient:
+    def __init__(self) -> None:
+        self._client = Client(mcp_server)
+
+    async def complete(self, context: Dict[str, Any], user_query: str) -> Completion:
+        messages = [
+            {"role": "system", "content": "You are an API assistant."},
+            {"role": "user", "content": user_query},
+        ]
+        async with self._client as session:
+            tools = [t.model_dump() for t in await session.list_tools()]
+            first = await llm_chat(messages, tools=tools)
+            message = first["choices"][0]["message"]
+            if "tool_calls" in message:
+                call = message["tool_calls"][0]
+                args = json.loads(call["function"].get("arguments", "{}"))
+                result_content = await session.call_tool(call["function"]["name"], args)
+                tool_text = "\n".join(
+                    c.text for c in result_content if getattr(c, "text", None) is not None
+                )
+                messages.append({"role": "assistant", "tool_calls": [call]})
+                messages.append({"role": "tool", "tool_call_id": call["id"], "content": tool_text})
+                final = await llm_chat(messages)
+                text = final["choices"][0]["message"].get("content", "")
+            else:
+                text = message.get("content", "")
+        return Completion(text=text)
+
+
+mcp_client = MCPClient()

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,86 @@
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+from httpx import AsyncClient
+import httpx
+
+# Add backend path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import main
+from services import mcp_client as client_mod
+
+
+@pytest.mark.asyncio
+async def test_chat_list_apis(monkeypatch):
+    async def fake_llm_chat(messages, *, tools=None):
+        if any(m.get("role") == "tool" for m in messages):
+            return {"choices": [{"message": {"role": "assistant", "content": "listUsers"}}]}
+        if any("我们有几个API" in m.get("content", "") for m in messages if m.get("role") == "user"):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "1",
+                                    "type": "function",
+                                    "function": {"name": "list_apis", "arguments": "{}"},
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        return {"choices": [{"message": {"role": "assistant", "content": "done"}}]}
+
+    monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
+
+    transport = httpx.ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"message": "我们有几个API？"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "listUsers" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_chat_get_api_sample(monkeypatch):
+    async def fake_llm_chat(messages, *, tools=None):
+        if any(m.get("role") == "tool" for m in messages):
+            return {"choices": [{"message": {"role": "assistant", "content": "curl -X GET http://localhost:8000/api/users/{id}"}}]}
+        if any("getUser" in m.get("content", "") for m in messages if m.get("role") == "user"):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_api_sample",
+                                        "arguments": json.dumps({"api_name": "getUser"}),
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        return {"choices": [{"message": {"role": "assistant", "content": "sample"}}]}
+
+    monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
+
+    transport = httpx.ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"message": "给我 getUser 的示例"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "curl" in data["message"]


### PR DESCRIPTION
## Summary
- integrate FastMCP client with list_apis and get_api_sample tools
- create generic llm_chat helper
- expose `/chat` endpoint
- mount FastMCP server in FastAPI app
- add example environment file
- test chat API flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c2b0e49c8326a870a91759703115