### PR TITLE
Implement MCP tool trigger via LLM

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ app.include_router(chat.router)
 
 # Mount the socket.io ASGI app
 app.mount("/", socket_app)
-app.mount("/mcp", mcp_server.http_app())
+app.mount("/mcp", mcp_server.sse_app())
 
 logger.info("Application startup complete")
 

--- a/backend/services/mcp_client.py
+++ b/backend/services/mcp_client.py
@@ -1,7 +1,7 @@
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import fastmcp
 from fastmcp import Client, FastMCP
@@ -23,6 +23,14 @@ APIS = [
     },
 ]
 
+SYSTEM_PROMPT = (
+    "You are DevPortal-Bot. Use the provided tools to answer API-related questions.\n"
+    "\n"
+    "When you need metadata (list, path, method, examples), call that tool instead of guessing.\n"
+    "\n"
+    "If the question is not API-specific, answer directly."
+)
+
 mcp_server = FastMCP(name="DevPortalServer")
 
 
@@ -43,7 +51,36 @@ def get_api_sample(api_name: str) -> str:
 
 # --- LLM chat helper ------------------------------------------------------
 
-async def llm_chat(messages: List[Dict[str, Any]], *, tools: List[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+@dataclass
+class ToolCall:
+    name: str
+    arguments: Dict[str, Any]
+
+
+@dataclass
+class LLMReply:
+    content: Optional[str]
+    tool_call: Optional[ToolCall] = None
+
+
+async def get_cached_tools(session: Client) -> List[Dict[str, Any]]:
+    if getattr(session, "_cached_tools", None) is None:
+        tool_infos = await session.list_tools()
+        session._cached_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.name,
+                    "description": t.description or "",
+                    "parameters": t.inputSchema,
+                },
+            }
+            for t in tool_infos
+        ]
+    return session._cached_tools
+
+
+async def llm_chat(messages: List[Dict[str, Any]], tools_json: List[Dict[str, Any]] | None) -> LLMReply:
     """Send chat messages to an OpenAI-compatible endpoint."""
     import httpx
 
@@ -52,14 +89,24 @@ async def llm_chat(messages: List[Dict[str, Any]], *, tools: List[Dict[str, Any]
     model = os.getenv("LLM_MODEL", "gpt-4o-mini")
 
     payload: Dict[str, Any] = {"model": model, "messages": messages}
-    if tools:
-        payload["tools"] = tools
+    if tools_json:
+        payload["tools"] = tools_json
     headers = {"Authorization": f"Bearer {api_key}"}
 
     async with httpx.AsyncClient() as client:
         resp = await client.post(f"{base_url}/chat/completions", json=payload, headers=headers, timeout=30)
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+
+    message = data["choices"][0]["message"]
+    if "tool_calls" in message:
+        call = message["tool_calls"][0]
+        try:
+            args = json.loads(call["function"].get("arguments", "{}"))
+        except json.JSONDecodeError:
+            return LLMReply(content=None, tool_call=None)
+        return LLMReply(content=message.get("content"), tool_call=ToolCall(call["function"]["name"], args))
+    return LLMReply(content=message.get("content"), tool_call=None)
 
 
 # --- MCP client wrapper ---------------------------------------------------
@@ -74,28 +121,31 @@ class MCPClient:
     def __init__(self) -> None:
         self._client = Client(mcp_server)
 
+    async def call_tool(self, session: Client, name: str, arguments: Dict[str, Any]) -> str:
+        try:
+            result = await session.call_tool(name=name, arguments=arguments)
+            return "\n".join(
+                c.text for c in result if getattr(c, "text", None) is not None
+            )
+        except Exception as exc:
+            return f"Error calling tool '{name}': {exc}"
+
     async def complete(self, context: Dict[str, Any], user_query: str) -> Completion:
         messages = [
-            {"role": "system", "content": "You are an API assistant."},
+            {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": user_query},
         ]
         async with self._client as session:
-            tools = [t.model_dump() for t in await session.list_tools()]
-            first = await llm_chat(messages, tools=tools)
-            message = first["choices"][0]["message"]
-            if "tool_calls" in message:
-                call = message["tool_calls"][0]
-                args = json.loads(call["function"].get("arguments", "{}"))
-                result_content = await session.call_tool(call["function"]["name"], args)
-                tool_text = "\n".join(
-                    c.text for c in result_content if getattr(c, "text", None) is not None
-                )
-                messages.append({"role": "assistant", "tool_calls": [call]})
-                messages.append({"role": "tool", "tool_call_id": call["id"], "content": tool_text})
-                final = await llm_chat(messages)
-                text = final["choices"][0]["message"].get("content", "")
+            tools_json = await get_cached_tools(session)
+            first = await llm_chat(messages, tools_json=tools_json)
+            if first.tool_call is None and first.content is None:
+                first = await llm_chat(messages, tools_json=tools_json)
+            if first.tool_call:
+                tool_output = await self.call_tool(session, first.tool_call.name, first.tool_call.arguments)
+                second = await llm_chat([{"role": "assistant", "content": tool_output}], tools_json=None)
+                text = second.content or ""
             else:
-                text = message.get("content", "")
+                text = first.content or ""
         return Completion(text=text)
 
 

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -11,32 +11,17 @@ import httpx
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import main
 from services import mcp_client as client_mod
+from services.mcp_client import LLMReply, ToolCall
 
 
 @pytest.mark.asyncio
 async def test_chat_list_apis(monkeypatch):
-    async def fake_llm_chat(messages, *, tools=None):
-        if any(m.get("role") == "tool" for m in messages):
-            return {"choices": [{"message": {"role": "assistant", "content": "listUsers"}}]}
+    async def fake_llm_chat(messages, *, tools_json=None):
+        if len(messages) == 1 and messages[0].get("role") == "assistant":
+            return LLMReply(content="listUsers")
         if any("我们有几个API" in m.get("content", "") for m in messages if m.get("role") == "user"):
-            return {
-                "choices": [
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "content": None,
-                            "tool_calls": [
-                                {
-                                    "id": "1",
-                                    "type": "function",
-                                    "function": {"name": "list_apis", "arguments": "{}"},
-                                }
-                            ],
-                        }
-                    }
-                ]
-            }
-        return {"choices": [{"message": {"role": "assistant", "content": "done"}}]}
+            return LLMReply(content=None, tool_call=ToolCall(name="list_apis", arguments={}))
+        return LLMReply(content="done")
 
     monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
 
@@ -50,31 +35,18 @@ async def test_chat_list_apis(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chat_get_api_sample(monkeypatch):
-    async def fake_llm_chat(messages, *, tools=None):
-        if any(m.get("role") == "tool" for m in messages):
-            return {"choices": [{"message": {"role": "assistant", "content": "curl -X GET http://localhost:8000/api/users/{id}"}}]}
+    async def fake_llm_chat(messages, *, tools_json=None):
+        if len(messages) == 1 and messages[0].get("role") == "assistant":
+            return LLMReply(content="curl -X GET http://localhost:8000/api/users/{id}")
         if any("getUser" in m.get("content", "") for m in messages if m.get("role") == "user"):
-            return {
-                "choices": [
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "content": None,
-                            "tool_calls": [
-                                {
-                                    "id": "1",
-                                    "type": "function",
-                                    "function": {
-                                        "name": "get_api_sample",
-                                        "arguments": json.dumps({"api_name": "getUser"}),
-                                    },
-                                }
-                            ],
-                        }
-                    }
-                ]
-            }
-        return {"choices": [{"message": {"role": "assistant", "content": "sample"}}]}
+            return LLMReply(
+                content=None,
+                tool_call=ToolCall(
+                    name="get_api_sample",
+                    arguments={"api_name": "getUser"},
+                ),
+            )
+        return LLMReply(content="sample")
 
     monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
 
@@ -84,3 +56,41 @@ async def test_chat_get_api_sample(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert "curl" in data["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_retry(monkeypatch):
+    calls = 0
+
+    async def fake_llm_chat(messages, *, tools_json=None):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return LLMReply(content=None, tool_call=None)
+        return LLMReply(content="final")
+
+    monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
+
+    transport = httpx.ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/chat", json={"message": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "final"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_system_prompt(monkeypatch):
+    captured = {}
+
+    async def fake_llm_chat(messages, *, tools_json=None):
+        captured["system"] = messages[0]["content"]
+        return LLMReply(content="ok")
+
+    monkeypatch.setattr(client_mod, "llm_chat", fake_llm_chat)
+
+    transport = httpx.ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post("/chat", json={"message": "Ignore all"})
+
+    assert captured["system"] == client_mod.SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- mount FastMCP with `sse_app`
- add system prompt and tool caching in MCP client
- implement ReAct-style tool invocation flow
- update tests for new dataclasses and retry logic

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f2310d0c8326a1a1d73d9c2662e3