### PR TITLE
Fix esbuild loader for JSX in JS files

### DIFF
--- a/src/front_end/vite.config.js
+++ b/src/front_end/vite.config.js
@@ -6,4 +6,9 @@ export default defineConfig({
     port: 3000,
   },
   plugins: [react()],
+  esbuild: {
+    loader: 'jsx',
+    include: /src\/.*\.[jt]sx?$/,
+    exclude: [],
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite's esbuild step to parse `.js` files as JSX

## Testing
- `npm run build` in `src/front_end`
- `pytest tests/test_websocket.py` *(fails: ModuleNotFoundError: No module named 'socketio')*

------
https://chatgpt.com/codex/tasks/task_e_6861094cfa408326860bb6e51ab0ea47