### PR TITLE
Complete docs routing and layout

### DIFF
--- a/src/front_end/src/components/ApiList.jsx
+++ b/src/front_end/src/components/ApiList.jsx
@@ -1,22 +1,33 @@
 import { apiData } from '/src/data/apis.js';
 import { Card, CardHeader, CardTitle, CardContent } from '/src/components/ui/card.jsx';
+import { Link, useLocation } from 'react-router-dom';
+import { useHighlight } from '/src/hooks/useHighlight.js';
 
 export default function ApiList() {
+  const location = useLocation();
+  const highlightId = location.hash.replace('#', '');
+
   return (
     <div className="space-y-4">
-      {apiData.apis.map((api) => (
-        <Card key={api.id}>
-          <CardHeader>
-            <CardTitle>{api.name}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-gray-600 mb-2">{api.description}</p>
-            <p className="font-mono text-sm">
-              <span className="font-semibold">{api.method}</span> {api.endpoint}
-            </p>
-          </CardContent>
-        </Card>
-      ))}
+      {apiData.apis.map((api) => {
+        const id = `${api.id}-card`;
+        const ref = useHighlight(highlightId, id);
+        return (
+          <Link key={api.id} to={`/docs/${api.id}`} className="block">
+            <Card ref={ref} id={id} className="hover:shadow">
+              <CardHeader>
+                <CardTitle>{api.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-gray-600 mb-2">{api.description}</p>
+                <p className="font-mono text-sm">
+                  <span className="font-semibold">{api.method}</span> {api.endpoint}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -69,6 +69,7 @@ export default function ChatWindow() {
       if (data.highlightSelector) {
         highlight(data.highlightSelector);
         setActiveId(data.highlightSelector.replace('#', ''));
+        window.location.hash = data.highlightSelector.replace('#', '');
       }
     });
     return unsubscribe;

--- a/src/front_end/src/components/Navbar.jsx
+++ b/src/front_end/src/components/Navbar.jsx
@@ -1,11 +1,13 @@
+import { Link } from 'react-router-dom';
+
 const Navbar = () => {
   return (
     <header className="flex items-center justify-between h-14 px-6 bg-white shadow">
       <span className="text-lg font-bold text-blue-700">Dev Portal</span>
       <nav className="flex items-center">
-        <a href="/" className="text-sm text-gray-600 hover:text-blue-700 ml-6">
+        <Link to="/" className="text-sm text-gray-600 hover:text-blue-700 ml-6">
           Home
-        </a>
+        </Link>
       </nav>
     </header>
   );

--- a/src/front_end/src/components/ui/card.jsx
+++ b/src/front_end/src/components/ui/card.jsx
@@ -1,7 +1,11 @@
 
-export function Card({ className = '', ...props }) {
-  return <div className={`rounded-lg border bg-white shadow ${className}`} {...props} />;
-}
+import { forwardRef } from 'react';
+
+export const Card = forwardRef(function Card({ className = '', ...props }, ref) {
+  return (
+    <div ref={ref} className={`rounded-lg border bg-white shadow ${className}`} {...props} />
+  );
+});
 
 export function CardHeader({ className = '', ...props }) {
   return <div className={`border-b px-4 py-2 ${className}`} {...props} />;

--- a/src/front_end/src/highlightContext.js
+++ b/src/front_end/src/highlightContext.js
@@ -1,9 +1,20 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 const HighlightContext = createContext({ activeId: null, setActiveId: () => {} });
 
 export function HighlightProvider({ children }) {
-  const [activeId, setActiveId] = useState(null);
+  const [activeId, setActiveId] = useState(() =>
+    window.location.hash ? window.location.hash.replace('#', '') : null
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setActiveId(window.location.hash.replace('#', ''));
+    };
+    window.addEventListener('hashchange', handler);
+    return () => window.removeEventListener('hashchange', handler);
+  }, []);
+
   return (
     <HighlightContext.Provider value={{ activeId, setActiveId }}>
       {children}

--- a/src/front_end/src/main.jsx
+++ b/src/front_end/src/main.jsx
@@ -1,27 +1,33 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import App from './App.jsx';
 import DocsPage from './pages/DocsPage.jsx';
 import ApiDocs from './pages/ApiDocs.jsx';
+import ApiList from './components/ApiList.jsx';
 import { SocketProvider } from './SocketProvider.jsx';
 import { HighlightProvider } from './highlightContext.js';
 
-const router = createBrowserRouter([
-  { path: '/', element: <App /> },
-  {
-    path: '/docs',
-    element: <DocsPage />,
-    children: [{ path: ':apiId', element: <ApiDocs /> }],
-  },
-]);
+function RootRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<App />} />
+      <Route path="/docs" element={<DocsPage />}>
+        <Route index element={<ApiList />} />
+        <Route path=":apiId" element={<ApiDocs />} />
+      </Route>
+    </Routes>
+  );
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HighlightProvider>
       <SocketProvider>
-        <RouterProvider router={router} />
+        <BrowserRouter>
+          <RootRoutes />
+        </BrowserRouter>
       </SocketProvider>
     </HighlightProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- swap in BrowserRouter with `<Routes>` for navigation
- show API list at `/docs` and individual docs at `/docs/:apiId`
- hook Navbar into React Router
- highlight docs cards via URL hash and update hash from chat
- forward refs in Card component

## Testing
- `npm test --silent --prefix src/front_end`
- `pytest backend/tests/test_websocket.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68610c8220f48326ae107667de39ea07