### PR TITLE
Add accordion grouped API list

### DIFF
--- a/src/front_end/src/components/ApiCard.jsx
+++ b/src/front_end/src/components/ApiCard.jsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import { useHighlight } from '/src/hooks/useHighlight.js';
+
+export default function ApiCard({ api, highlightId }) {
+  const id = `${api.id}-card`;
+  const ref = useHighlight(highlightId, id);
+  return (
+    <Link to={`/docs/${api.id}`} className="block">
+      <div
+        ref={ref}
+        id={id}
+        className="p-3 border rounded hover:bg-gray-50 cursor-pointer"
+      >
+        <h4 className="text-base font-semibold">{api.name}</h4>
+        <p className="text-sm text-gray-600">{api.description}</p>
+        <div className="mt-1 flex gap-2 items-center">
+          <span className="inline-block px-2 py-1 bg-blue-700 text-white text-xs rounded">
+            {api.method}
+          </span>
+          <code className="text-xs">{api.endpoint}</code>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/front_end/src/components/ApiList.jsx
+++ b/src/front_end/src/components/ApiList.jsx
@@ -1,7 +1,7 @@
-import { apiData } from '/src/data/apis.js';
-import { Card, CardHeader, CardTitle, CardContent } from '/src/components/ui/card.jsx';
-import { Link, useLocation } from 'react-router-dom';
-import { useHighlight } from '/src/hooks/useHighlight.js';
+import { apiGroups } from '/src/data/apiGroups.js';
+import Accordion from '/src/components/ui/accordion.jsx';
+import ApiCard from '/src/components/ApiCard.jsx';
+import { useLocation } from 'react-router-dom';
 
 export default function ApiList() {
   const location = useLocation();
@@ -9,25 +9,13 @@ export default function ApiList() {
 
   return (
     <div className="space-y-4">
-      {apiData.apis.map((api) => {
-        const id = `${api.id}-card`;
-        const ref = useHighlight(highlightId, id);
-        return (
-          <Link key={api.id} to={`/docs/${api.id}`} className="block">
-            <Card ref={ref} id={id} className="hover:shadow">
-              <CardHeader>
-                <CardTitle>{api.name}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-gray-600 mb-2">{api.description}</p>
-                <p className="font-mono text-sm">
-                  <span className="font-semibold">{api.method}</span> {api.endpoint}
-                </p>
-              </CardContent>
-            </Card>
-          </Link>
-        );
-      })}
+      {apiGroups.map((group, idx) => (
+        <Accordion key={group.title} title={group.title} defaultOpen={idx === 0}>
+          {group.apis.map((api) => (
+            <ApiCard key={api.id} api={api} highlightId={highlightId} />
+          ))}
+        </Accordion>
+      ))}
     </div>
   );
 }

--- a/src/front_end/src/components/ui/accordion.jsx
+++ b/src/front_end/src/components/ui/accordion.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export default function Accordion({ title, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border rounded">
+      <button
+        type="button"
+        className="w-full flex justify-between items-center p-3 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <span className="font-semibold text-sm">{title}</span>
+        <span className="ml-2">{open ? '-' : '+'}</span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="p-2 space-y-2">{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/front_end/src/data/apiGroups.js
+++ b/src/front_end/src/data/apiGroups.js
@@ -1,0 +1,62 @@
+import { apiData } from './apis.js';
+
+const find = (id) => apiData.apis.find((a) => a.id === id);
+
+export const apiGroups = [
+  {
+    title: 'Dynamic Client Registration APIs',
+    apis: [
+      find('dcr-register-client'),
+      find('dcr-get-client'),
+      find('dcr-update-client'),
+      find('dcr-delete-client'),
+    ],
+  },
+  {
+    title: 'Authorization APIs',
+    apis: [
+      find('oauth-authorize'),
+      find('oauth-par'),
+      find('oauth-token'),
+      find('oauth-revoke'),
+      find('oauth-introspect'),
+    ],
+  },
+  {
+    title: 'Products',
+    apis: [find('get-products'), find('get-product-detail')],
+  },
+  {
+    title: 'Accounts',
+    apis: [find('get-accounts'), find('get-account-detail')],
+  },
+  {
+    title: 'Balances',
+    apis: [find('get-bulk-balances'), find('get-account-balance')],
+  },
+  {
+    title: 'Transactions',
+    apis: [find('get-account-transactions'), find('get-transaction-detail')],
+  },
+  {
+    title: 'Direct Debits',
+    apis: [find('get-account-direct-debits'), find('get-bulk-direct-debits')],
+  },
+  {
+    title: 'Scheduled Payments',
+    apis: [find('get-account-scheduled-payments'), find('get-bulk-scheduled-payments')],
+  },
+  {
+    title: 'Payees',
+    apis: [find('get-payees'), find('get-payee-detail')],
+  },
+  {
+    title: 'Common APIs',
+    apis: [
+      find('get-customer'),
+      find('get-customer-detail'),
+      find('get-common-status'),
+      find('get-common-outages'),
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- group APIs into categories in `apiGroups.js`
- show API list in an accordion with highlighting
- add reusable `ApiCard` and `Accordion` components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861149e756083269656278812ad7233