### PR TITLE
Add enhanced MCP tools and tests

### DIFF
--- a/backend/services/mcp_client.py
+++ b/backend/services/mcp_client.py
@@ -10,16 +10,28 @@ from fastmcp import Client, FastMCP
 
 APIS = [
     {
+        "id": "list-users",
         "name": "listUsers",
-        "path": "/api/users",
-        "method": "GET",
         "description": "List all users",
+        "endpoint": "/api/users",
+        "method": "GET",
+        "parameters": [],
+        "curlExample": "curl -X GET '<baseURL>/api/users'",
+        "responseExample": '{"data": [{"id": 1, "name": "Alice"}]}',
+        "fields": [],
     },
     {
+        "id": "get-user",
         "name": "getUser",
-        "path": "/api/users/{id}",
-        "method": "GET",
         "description": "Get a specific user",
+        "endpoint": "/api/users/{id}",
+        "method": "GET",
+        "parameters": [
+            {"name": "id", "type": "string", "description": "User identifier"}
+        ],
+        "curlExample": "curl -X GET '<baseURL>/api/users/{id}'",
+        "responseExample": '{"data": {"id": 1, "name": "Alice"}}',
+        "fields": [],
     },
 ]
 
@@ -35,17 +47,68 @@ mcp_server = FastMCP(name="DevPortalServer")
 
 
 @mcp_server.tool(name="list_apis")
-def list_all_http_apis() -> List[Dict[str, str]]:
-    """Return **every** available HTTP-API with `name`, `method`, `path`, and `description`. Use **ONLY** when the user asks to *“list / show / enumerate / count all APIs, endpoints or routes”.*"""
-    return APIS
+def list_apis() -> List[Dict[str, str]]:
+    """List all available HTTP APIs with name, method, endpoint, and description."""
+    return [
+        {
+            "name": api["name"],
+            "method": api["method"],
+            "endpoint": api["endpoint"],
+            "description": api["description"],
+        }
+        for api in APIS
+    ]
+
+
+@mcp_server.tool(name="get_api_details")
+def get_api_details(api_name: str) -> Dict[str, Any]:
+    """Provide detailed information (method, endpoint, parameters, response example) about a specific API."""
+    for api in APIS:
+        if api["name"].lower() == api_name.lower():
+            return api
+    raise ValueError(f"API '{api_name}' not found")
 
 
 @mcp_server.tool(name="get_api_sample")
-def generate_curl_example_for_api(api_name: str) -> str:
-    """Return a ready-to-run `curl` command for the specified API `name`. Invoke when the user wants a **sample request, example call, or usage snippet** for a single endpoint."""
+def get_api_sample(api_name: str) -> str:
+    """Return a ready-to-run curl command for the specified API."""
     for api in APIS:
         if api_name.lower() == api["name"].lower():
-            return f"curl -X {api['method']} http://localhost:8000{api['path']}"
+            return api["curlExample"]
+    raise ValueError(f"API '{api_name}' not found")
+
+
+@mcp_server.tool(name="search_apis")
+def search_apis(keyword: str) -> List[Dict[str, str]]:
+    """Search and return APIs matching a keyword."""
+    keyword_lower = keyword.lower()
+    return [
+        {
+            "name": api["name"],
+            "method": api["method"],
+            "endpoint": api["endpoint"],
+            "description": api["description"],
+        }
+        for api in APIS
+        if keyword_lower in api["name"].lower() or keyword_lower in api["description"].lower()
+    ]
+
+
+@mcp_server.tool(name="get_api_parameters")
+def get_api_parameters(api_name: str) -> List[Dict[str, str]]:
+    """Return parameters for the specified API."""
+    for api in APIS:
+        if api_name.lower() == api["name"].lower():
+            return api.get("parameters", [])
+    raise ValueError(f"API '{api_name}' not found")
+
+
+@mcp_server.tool(name="get_api_response_example")
+def get_api_response_example(api_name: str) -> str:
+    """Provide an example JSON response for the specified API."""
+    for api in APIS:
+        if api_name.lower() == api["name"].lower():
+            return api["responseExample"]
     raise ValueError(f"API '{api_name}' not found")
 
 

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from services.mcp_client import (
+    APIS,
+    list_apis,
+    get_api_details,
+    get_api_sample,
+    search_apis,
+    get_api_parameters,
+    get_api_response_example,
+)
+
+# Decorated tools return FunctionTool objects; underlying callables are in `.fn`.
+list_apis_fn = list_apis.fn
+get_api_details_fn = get_api_details.fn
+get_api_sample_fn = get_api_sample.fn
+search_apis_fn = search_apis.fn
+get_api_parameters_fn = get_api_parameters.fn
+get_api_response_example_fn = get_api_response_example.fn
+
+
+def test_list_apis():
+    apis = list_apis_fn()
+    assert len(apis) == len(APIS)
+    assert all({"name", "method", "endpoint", "description"} <= api.keys() for api in apis)
+
+
+def test_get_api_details_success():
+    details = get_api_details_fn("listUsers")
+    assert details["name"] == "listUsers"
+
+
+def test_get_api_details_failure():
+    with pytest.raises(ValueError):
+        get_api_details_fn("unknown")
+
+
+def test_get_api_sample_success():
+    sample = get_api_sample_fn("getUser")
+    assert "curl" in sample
+
+
+def test_get_api_sample_failure():
+    with pytest.raises(ValueError):
+        get_api_sample_fn("bad")
+
+
+def test_search_apis():
+    results = search_apis_fn("user")
+    assert len(results) >= 1
+
+    empty = search_apis_fn("nonexistent")
+    assert empty == []
+
+
+def test_get_api_parameters():
+    params = get_api_parameters_fn("getUser")
+    assert isinstance(params, list) and params
+
+    with pytest.raises(ValueError):
+        get_api_parameters_fn("bad")
+
+
+def test_get_api_response_example():
+    resp = get_api_response_example_fn("listUsers")
+    assert "data" in resp
+
+    with pytest.raises(ValueError):
+        get_api_response_example_fn("bad")


### PR DESCRIPTION
## Summary
- expand API metadata for DevPortal bot
- implement new MCP tools: list, details, samples, searching, params and responses
- provide unit tests for tool functions

## Testing
- `pytest backend/tests/test_chat.py -q`
- `pytest backend/tests/test_mcp_tools.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686119236b708326814135a1c8a8ca2d