### PR TITLE
Use Tavily SDK for spec comparisons

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]
 python-socketio
 aiohttp
 httpx
+tavily-python
 
 fastmcp>=0.5.0
 mcp[cli]

--- a/backend/services/mcp_client.py
+++ b/backend/services/mcp_client.py
@@ -797,7 +797,7 @@ def compare_api_specs(api_name: str, external_query: str) -> str:
     the internal API with the discovered external details.
     """
 
-    import httpx
+    from tavily import TavilyClient
     import re
 
     internal = None
@@ -812,13 +812,8 @@ def compare_api_specs(api_name: str, external_query: str) -> str:
     if not api_key:
         raise RuntimeError("SEARCH_API_KEY not configured")
 
-    resp = httpx.post(
-        "https://api.tavily.com/search",
-        json={"api_key": api_key, "query": external_query, "max_results": 3},
-        timeout=10,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    tavily_client = TavilyClient(api_key=api_key)
+    data = tavily_client.search(query=external_query, max_results=3)
 
     ext_text = ""
     source_url = ""

--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -89,21 +89,12 @@ def test_compare_api_specs(monkeypatch):
         ]
     }
 
-    class FakeResp:
-        def __init__(self, data):
-            self._data = data
+    def fake_search(self, query, max_results=3):
+        assert max_results == 3
+        return result_json
 
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return self._data
-
-    def fake_post(url, json, timeout):
-        return FakeResp(result_json)
-
-    import httpx
-    monkeypatch.setattr(httpx, "post", fake_post)
+    from tavily import TavilyClient
+    monkeypatch.setattr(TavilyClient, "search", fake_search)
     monkeypatch.setenv("SEARCH_API_KEY", "x")
 
     name = APIS[0]["name"]


### PR DESCRIPTION
## Summary
- call Tavily via TavilyClient in `compare_api_specs`
- install `tavily-python`
- update tests for new Tavily client

## Testing
- `pip install -r backend/requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617641b9548326843e5e35636dc30d