### PR TITLE
Refactor agent mode with LangChain streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ information are handled via MCP instead of manual WebSocket payloads.
 When Agent Mode is enabled, the LLM can make real-time web searches via the
 Tavily API. Set a `SEARCH_API_KEY` in your `.env` file for this feature.
 
+Agent Mode now leverages **LangChain's AgentExecutor** to autonomously call MCP
+tools. Streaming responses are delivered over the existing WebSocket channel so
+tokens appear progressively in the chat UI.
+
 ## Getting Started
 
 Install dependencies (if your environment allows network access) from the

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,8 @@ tavily-python
 fastmcp>=0.5.0
 mcp[cli]
 python-dotenv
+langchain>=0.2.0
+langchain-openai
 
 pytest
 pytest-asyncio

--- a/backend/services/agent_factory.py
+++ b/backend/services/agent_factory.py
@@ -1,0 +1,21 @@
+from typing import Optional, Sequence
+
+from langchain_openai import ChatOpenAI
+from langchain.agents import AgentExecutor, create_openai_functions_agent
+from langchain.callbacks.base import BaseCallbackHandler
+
+from .mcp_client import structured_mcp_tools
+
+
+def create_agent(llm: Optional[ChatOpenAI] = None, callbacks: Optional[Sequence[BaseCallbackHandler]] = None) -> AgentExecutor:
+    """Create a LangChain AgentExecutor using existing MCP tools."""
+    if llm is None:
+        llm = ChatOpenAI(streaming=True)
+    agent = create_openai_functions_agent(llm, structured_mcp_tools)
+    return AgentExecutor(
+        agent=agent,
+        tools=structured_mcp_tools,
+        callbacks=list(callbacks) if callbacks else None,
+        max_iterations=6,
+        verbose=True,
+    )

--- a/backend/services/mcp_client.py
+++ b/backend/services/mcp_client.py
@@ -974,3 +974,21 @@ class MCPClient:
 
 
 mcp_client = MCPClient()
+
+# LangChain adapter for MCP tools --------------------------------------------
+from langchain.tools import StructuredTool
+
+
+def _generate_structured_tools() -> list[StructuredTool]:
+    """Convert registered FastMCP tools to LangChain StructuredTool objects."""
+    return [
+        StructuredTool.from_function(
+            t.fn,
+            name=t.name,
+            description=t.description or "",
+        )
+        for t in mcp_server.list_tools()
+    ]
+
+
+structured_mcp_tools = _generate_structured_tools()


### PR DESCRIPTION
## Summary
- integrate LangChain and StructuredTool wrappers for MCP tools
- implement AgentExecutor factory
- refactor agent mode handler to use LangChain agent with optional streaming
- stream tokens over WebSocket
- update documentation
- expand tests for agent mode and streaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619e4c48708326b9fb468f2fa2ba8d