### PR TITLE
Fix Socket.IO CORS error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers import api, chat
 from services.mcp_client import mcp_server
-from sockets.websocket import socket_app
+from sockets.websocket import sio
+import socketio
 from dotenv import load_dotenv
 
 logging.basicConfig(level=logging.INFO)
@@ -26,9 +27,11 @@ app.add_middleware(
 app.include_router(api.router)
 app.include_router(chat.router)
 
-# Mount the socket.io ASGI app
-app.mount("/", socket_app)
+# Mount the SSE app
 app.mount("/mcp", mcp_server.sse_app())
+
+# Wrap the FastAPI app with Socket.IO ASGI app
+app = socketio.ASGIApp(sio, other_asgi_app=app)
 
 logger.info("Application startup complete")
 

--- a/backend/sockets/websocket.py
+++ b/backend/sockets/websocket.py
@@ -11,9 +11,6 @@ from services.mode_handlers import (
 # Setup Async WebSocket server
 sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins='*')
 
-# ASGI application to mount in FastAPI
-socket_app = socketio.ASGIApp(sio)
-
 
 class WebSocketStreamHandler(BaseCallbackHandler):
     """Stream LLM tokens to the websocket client."""

--- a/src/front_end/src/SocketProvider.jsx
+++ b/src/front_end/src/SocketProvider.jsx
@@ -8,7 +8,10 @@ export function SocketProvider({ children }) {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    const socket = io('http://localhost:8000');
+    const socket = io('http://localhost:8000', {
+      transports: ['websocket'],
+      withCredentials: true,
+    });
     socketRef.current = socket;
 
     socket.on('connect', () => {


### PR DESCRIPTION
## Summary
- integrate FastAPI with Socket.IO using ASGIApp so CORS applies to `/socket.io`
- update frontend SocketProvider to explicitly configure transports and credentials

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862bf99ae388326bdb0dc5663690b4f