### PR TITLE
Fix SSE parsing in chat window

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -123,12 +123,11 @@ export default function ChatWindow() {
                 return;
               }
               buffer += decoder.decode(value, { stream: true });
-              let lines = buffer.split('\n\n');
+              let lines = buffer.split(/\r?\n/);
               buffer = lines.pop();
               for (const line of lines) {
-                const match = line.match(/^data: (.*)/);
-                if (!match) continue;
-                const data = match[1];
+                if (!line.startsWith('data:')) continue;
+                const data = line.slice(5).trim();
                 if (data === '[DONE]') {
                   setIsLoading(false);
                   controller.abort();


### PR DESCRIPTION
## Summary
- parse SSE stream by newline so CRLF works

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, fastmcp, socketio)*

------
https://chatgpt.com/codex/tasks/task_e_6862c80622d083268066e6667750d389