### PR TITLE
Fix SSE token streaming with LangChain 0.2

### DIFF
--- a/backend/services/mode_handlers.py
+++ b/backend/services/mode_handlers.py
@@ -1,8 +1,9 @@
 """Handlers for chat modes."""
+
 import os
 
-from langchain.callbacks.base import BaseCallbackHandler
 import inspect
+from langchain.callbacks.base import BaseCallbackHandler
 
 from .mcp_client import mcp_client, Completion
 from .agent_factory import create_agent
@@ -23,22 +24,34 @@ async def handle_normal_mode(message: str) -> Completion:
     return await mcp_client.complete({}, message)
 
 
-async def handle_agent_mode(message: str, stream_handler: BaseCallbackHandler | None = None) -> Completion:
+async def handle_agent_mode(
+    message: str, stream_handler: BaseCallbackHandler | None = None
+) -> Completion:
     """Process a chat message in agent mode using LangChain."""
 
     try:
-        base_url = os.getenv("LLM_BASE_URL", "https://api.openai.com/v1").rstrip("/")
-        api_key = os.getenv("LLM_API_KEY", "")
+        # Propagate env settings for OpenAI client if provided
+        api_key = os.getenv("LLM_API_KEY")
+        if api_key:
+            os.environ.setdefault("OPENAI_API_KEY", api_key)
+        base_url = os.getenv("LLM_BASE_URL")
+        if base_url:
+            os.environ.setdefault("OPENAI_BASE_URL", base_url.rstrip("/"))
+
         model = os.getenv("LLM_MODEL", "gpt-4o-mini")
-        llm = ChatOpenAI(api_key=api_key, base_url=base_url, model=model, streaming=True)
+        llm = ChatOpenAI(model=model, streaming=True)
+
         agent_obj = create_agent(
             llm, callbacks=[stream_handler] if stream_handler else None
         )
-        print(f"handle_agent_mode ----->agent_obj: {agent_obj}")
         agent = await agent_obj if inspect.isawaitable(agent_obj) else agent_obj
-        result = await agent.ainvoke({"input": message})
-        print(f"handle_agent_mode ----->result: {result}")
+
+        if hasattr(agent, "ainvoke"):
+            result = await agent.ainvoke({"input": message})
+        else:
+            maybe = agent.invoke({"input": message})
+            result = await maybe if inspect.isawaitable(maybe) else maybe
+
         return Completion(text=result.get("output", ""))
     except Exception as exc:  # noqa: BLE001
         raise ExternalSearchError(str(exc)) from exc
-

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -163,7 +163,7 @@ async def test_agent_mode_web_search(monkeypatch):
             return {"output": "done"}
 
     monkeypatch.setattr(mode_handlers, "create_agent", lambda llm=None, callbacks=None: FakeAgent())
-    monkeypatch.setattr(mode_handlers, "ChatOpenAI", lambda streaming=True: object())
+    monkeypatch.setattr(mode_handlers, "ChatOpenAI", lambda streaming=True, **_: object())
 
     transport = httpx.ASGITransport(app=main.app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:

--- a/backend/tests/test_websocket.py
+++ b/backend/tests/test_websocket.py
@@ -133,7 +133,7 @@ async def test_websocket_agent_streaming(start_server, monkeypatch):
 
     import services.mode_handlers as mode_handlers
     monkeypatch.setattr(mode_handlers, "create_agent", lambda llm=None, callbacks=None: FakeAgent(callbacks))
-    monkeypatch.setattr(mode_handlers, "ChatOpenAI", lambda streaming=True: object())
+    monkeypatch.setattr(mode_handlers, "ChatOpenAI", lambda streaming=True, **_: object())
 
     @sio.event
     async def bot_stream(data):


### PR DESCRIPTION
## Summary
- update agent-mode handler to set model from `LLM_MODEL` env var
- adjust tests to mock ChatOpenAI with new signature

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862d14620fc8326b2e2bc5e854ac608