### PR TITLE
Fix markdown tables rendering in chat UI

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -216,6 +216,7 @@ export default function ChatWindow() {
                 {m.sender === 'bot' ? (
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
+                    linkTarget="_blank"
                     components={{
                       code({ inline, className, children, ...props }) {
                         const match = /language-(\w+)/.exec(className || '');
@@ -233,6 +234,15 @@ export default function ChatWindow() {
                           </div>
                         ) : (
                           <code className="bg-gray-200 px-1 rounded">{children}</code>
+                        );
+                      },
+                      table({ children }) {
+                        return (
+                          <div className="overflow-auto">
+                            <table className="min-w-full border-collapse">
+                              {children}
+                            </table>
+                          </div>
                         );
                       },
                     }}


### PR DESCRIPTION
## Summary
- ensure tables render correctly in chat messages
- open links in a new tab for convenience

## Testing
- `npm test`
- `pytest backend/tests/test_websocket.py`


------
https://chatgpt.com/codex/tasks/task_e_6862da3435f083268854a8ce6279f46c