### PR TITLE
Fix ReactMarkdown link targets

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -216,7 +216,6 @@ export default function ChatWindow() {
                 {m.sender === 'bot' ? (
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
-                    linkTarget="_blank"
                     components={{
                       code({ inline, className, children, ...props }) {
                         const match = /language-(\w+)/.exec(className || '');
@@ -234,6 +233,11 @@ export default function ChatWindow() {
                           </div>
                         ) : (
                           <code className="bg-gray-200 px-1 rounded">{children}</code>
+                        );
+                      },
+                      a({ node, ...props }) {
+                        return (
+                          <a target="_blank" rel="noopener noreferrer" {...props} />
                         );
                       },
                       table({ children }) {


### PR DESCRIPTION
## Summary
- update `ChatWindow` to override anchor rendering instead of using `linkTarget`
- open markdown links in new tab

## Testing
- `npm --prefix src/front_end test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6862dcae6ffc8326a218c4d729768c0b