### PR TITLE
Enable Markdown tables with remark-gfm

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -38,8 +38,7 @@ function MinusIcon(props) {
 import React, { useEffect, useRef, useState } from 'react';
 import ModeSelector from './ModeSelector.jsx';
 import { AnimatePresence, motion } from 'framer-motion';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import MarkdownRenderer from './MarkdownRenderer.jsx';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 // SSE streaming does not rely on the existing WebSocket utilities
 
@@ -214,8 +213,7 @@ export default function ChatWindow() {
                 }`}
               >
                 {m.sender === 'bot' ? (
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
+                  <MarkdownRenderer
                     components={{
                       code({ inline, className, children, ...props }) {
                         const match = /language-(\w+)/.exec(className || '');
@@ -235,24 +233,10 @@ export default function ChatWindow() {
                           <code className="bg-gray-200 px-1 rounded">{children}</code>
                         );
                       },
-                      a({ node, ...props }) {
-                        return (
-                          <a target="_blank" rel="noopener noreferrer" {...props} />
-                        );
-                      },
-                      table({ children }) {
-                        return (
-                          <div className="overflow-auto">
-                            <table className="min-w-full border-collapse">
-                              {children}
-                            </table>
-                          </div>
-                        );
-                      },
                     }}
                   >
                     {m.text}
-                  </ReactMarkdown>
+                  </MarkdownRenderer>
                 ) : (
                   m.text
                 )}

--- a/src/front_end/src/components/MarkdownRenderer.jsx
+++ b/src/front_end/src/components/MarkdownRenderer.jsx
@@ -1,0 +1,27 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export default function MarkdownRenderer({ children, components = {} }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a({ node, ...props }) {
+          return <a target="_blank" rel="noopener noreferrer" {...props} />;
+        },
+        table({ children }) {
+          return (
+            <div className="overflow-auto">
+              <table className="min-w-full border-collapse">
+                {children}
+              </table>
+            </div>
+          );
+        },
+        ...components,
+      }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}


### PR DESCRIPTION
## Summary
- create `MarkdownRenderer` component wrapping ReactMarkdown
- use the new component in `ChatWindow`

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862decaca1483268d80782f1ef6a4d3