### PR TITLE
Fix SSE newline escaping

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -46,7 +46,8 @@ async def chat(req: ChatRequest):
                 token = await queue.get()
                 if token is None:
                     break
-                yield f"data: {token}\n\n"
+                # Include a literal "\n" between tokens so Markdown tables render correctly
+                yield f"data: {token}\\n\n\n"
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -197,6 +197,6 @@ async def test_chat_agent_streaming(monkeypatch):
                 if line:
                     tokens.append(line)
 
-    assert "data: hi" in tokens
+    assert "data: hi\\n" in tokens
     assert tokens[-1] == "data: [DONE]"
 

--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -140,7 +140,7 @@ export default function ChatWindow() {
                 setMessages((msgs) =>
                   msgs.map((m, idx) =>
                     idx === botIndex
-                      ? { ...m, raw: (m.raw || '') + data }
+                      ? { ...m, raw: (m.raw || '') + data.replace(/\\n/g, '\n') }
                       : m
                   )
                 );


### PR DESCRIPTION
## Summary
- encode newlines as `\n` when streaming tokens
- decode escaped newlines on the frontend while streaming
- update streaming test to expect encoded newlines

## Testing
- `pytest -q backend/tests/test_chat.py`
- `npm test --prefix src/front_end`


------
https://chatgpt.com/codex/tasks/task_e_6862e4d55fb083269d602f7daaba5072