### PR TITLE
Fix SSE newline rendering

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -120,9 +120,11 @@ export default function ChatWindow() {
           const decoder = new TextDecoder();
           let buffer = '';
 
+          const decode = (str) => str.replace(/\\n/g, '\n');
+
           const flushPending = () => {
             if (pendingTokensRef.current) {
-              const pending = pendingTokensRef.current;
+              const pending = decode(pendingTokensRef.current);
               pendingTokensRef.current = '';
               setMessages((msgs) =>
                 msgs.map((m, idx) =>
@@ -144,7 +146,7 @@ export default function ChatWindow() {
               buffer = lines.pop();
               for (const line of lines) {
                 if (!line.startsWith('data:')) continue;
-                const data = line.slice(5).trim();
+                const data = decode(line.slice(5).trim());
                 if (data === '[DONE]') {
                   flushPending();
                   setIsLoading(false);


### PR DESCRIPTION
## Summary
- decode escaped newlines when streaming chat messages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6862eabdf178832687ab952328ee745f