### PR TITLE
Fix SSE newline handling

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -46,8 +46,9 @@ async def chat(req: ChatRequest):
                 token = await queue.get()
                 if token is None:
                     break
-                # Include a literal "\n" between tokens so Markdown tables render correctly
-                yield f"data: {token}\\n\n\n"
+                # Escape newline characters so the SSE protocol remains valid
+                encoded = token.replace("\n", "\\n")
+                yield f"data: {encoded}\n\n"
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -197,6 +197,6 @@ async def test_chat_agent_streaming(monkeypatch):
                 if line:
                     tokens.append(line)
 
-    assert "data: hi\\n" in tokens
+    assert "data: hi" in tokens
     assert tokens[-1] == "data: [DONE]"
 


### PR DESCRIPTION
## Summary
- escape newline characters when streaming tokens
- adjust chat test expectations

## Testing
- `pip install -q -r requirements.txt && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ecf632408326ba55312c6bb587b1