### PR TITLE
Fix whitespace for SSE streaming

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -146,7 +146,9 @@ export default function ChatWindow() {
               buffer = lines.pop();
               for (const line of lines) {
                 if (!line.startsWith('data:')) continue;
-                const data = decode(line.slice(5).trim());
+                // Slice off the leading "data: " prefix while preserving
+                // any intentional whitespace in the token itself.
+                const data = decode(line.slice(6));
                 if (data === '[DONE]') {
                   flushPending();
                   setIsLoading(false);


### PR DESCRIPTION
## Summary
- keep whitespace in SSE tokens when parsing stream events

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6862efeffc4c8326bd8ebb7074edd025