### PR TITLE
Add API usage flow tool with Mermaid diagrams

### DIFF
--- a/backend/tests/test_mcp_tools.py
+++ b/backend/tests/test_mcp_tools.py
@@ -13,6 +13,7 @@ from services.mcp_client import (
     get_api_parameters,
     get_api_response_example,
     compare_api_specs,
+    get_api_usage_flow,
 )
 
 # Decorated tools return FunctionTool objects; underlying callables are in `.fn`.
@@ -23,6 +24,7 @@ search_apis_fn = search_apis.fn
 get_api_parameters_fn = get_api_parameters.fn
 get_api_response_example_fn = get_api_response_example.fn
 compare_api_specs_fn = compare_api_specs.fn
+get_api_usage_flow_fn = get_api_usage_flow.fn
 
 
 def test_list_apis():
@@ -100,3 +102,17 @@ def test_compare_api_specs(monkeypatch):
     name = APIS[0]["name"]
     table = compare_api_specs_fn(name, "UK PSD2 authorization API")
     assert "/oauth2/authorize" in table
+
+
+def test_get_api_usage_flow():
+    result = get_api_usage_flow_fn("authorization")
+    assert "Authorization Flow" in result
+    assert "sequenceDiagram" in result
+
+    result = get_api_usage_flow_fn("dcr")
+    assert "DCR Flow" in result
+    assert "sequenceDiagram" in result
+
+    result = get_api_usage_flow_fn("resource")
+    assert "Resource API Usage" in result
+    assert "sequenceDiagram" in result

--- a/src/front_end/src/components/MarkdownRenderer.jsx
+++ b/src/front_end/src/components/MarkdownRenderer.jsx
@@ -1,27 +1,41 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import mermaid from 'mermaid';
+import { useEffect, useRef } from 'react';
+
+mermaid.initialize({ startOnLoad: true });
 
 export default function MarkdownRenderer({ children, components = {} }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      mermaid.init(undefined, containerRef.current.querySelectorAll('.language-mermaid'));
+    }
+  }, [children]);
+
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        a({ node, ...props }) {
-          return <a target="_blank" rel="noopener noreferrer" {...props} />;
-        },
-        table({ children }) {
-          return (
-            <div className="overflow-auto">
-              <table className="min-w-full border-collapse">
-                {children}
-              </table>
-            </div>
-          );
-        },
-        ...components,
-      }}
-    >
-      {children}
-    </ReactMarkdown>
+    <div ref={containerRef}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a({ node, ...props }) {
+            return <a target="_blank" rel="noopener noreferrer" {...props} />;
+          },
+          table({ children }) {
+            return (
+              <div className="overflow-auto">
+                <table className="min-w-full border-collapse">
+                  {children}
+                </table>
+              </div>
+            );
+          },
+          ...components,
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement `get_api_usage_flow` MCP tool
- render mermaid diagrams in `MarkdownRenderer`
- test new tool in backend

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863bbe7fb408326ae1e330093445241