### PR TITLE
Fix mermaid rendering

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -249,6 +249,13 @@ export default function ChatWindow() {
                       components={{
                         code({ inline, className, children, ...props }) {
                           const match = /language-(\w+)/.exec(className || '');
+                          if (!inline && match && match[1] === 'mermaid') {
+                            return (
+                              <pre className="mermaid">
+                                {String(children).replace(/\n$/, '')}
+                              </pre>
+                            );
+                          }
                           return !inline ? (
                             <div className="relative">
                               <button

--- a/src/front_end/src/components/MarkdownRenderer.jsx
+++ b/src/front_end/src/components/MarkdownRenderer.jsx
@@ -10,7 +10,12 @@ export default function MarkdownRenderer({ children, components = {} }) {
 
   useEffect(() => {
     if (containerRef.current) {
-      mermaid.init(undefined, containerRef.current.querySelectorAll('.language-mermaid'));
+      const blocks = containerRef.current.querySelectorAll(
+        '.language-mermaid, .mermaid'
+      );
+      if (blocks.length > 0) {
+        mermaid.init(undefined, blocks);
+      }
     }
   }, [children]);
 


### PR DESCRIPTION
## Summary
- special case mermaid code blocks so highlight wrapper doesn't corrupt them
- init mermaid on any `.mermaid` element

## Testing
- `pytest backend/tests/test_mcp_tools.py` *(fails: ModuleNotFoundError fastmcp)*

------
https://chatgpt.com/codex/tasks/task_e_6863bf7a01288326a9e0c17d694f1149