### PR TITLE
Fix mermaid diagram rendering

### DIFF
--- a/src/front_end/src/components/ChatWindow.jsx
+++ b/src/front_end/src/components/ChatWindow.jsx
@@ -251,9 +251,9 @@ export default function ChatWindow() {
                           const match = /language-(\w+)/.exec(className || '');
                           if (!inline && match && match[1] === 'mermaid') {
                             return (
-                              <pre className="mermaid">
+                              <code className="language-mermaid mermaid">
                                 {String(children).replace(/\n$/, '')}
-                              </pre>
+                              </code>
                             );
                           }
                           return !inline ? (


### PR DESCRIPTION
## Summary
- ensure custom code block for mermaid returns `<code>` not `<pre>`
  so ReactMarkdown produces valid markup

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ImportError: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_6863c43458108326b3a289fdf6e808a7