### PR TITLE
Improve mermaid arrow contrast

### DIFF
--- a/src/front_end/src/components/MarkdownRenderer.jsx
+++ b/src/front_end/src/components/MarkdownRenderer.jsx
@@ -3,7 +3,13 @@ import remarkGfm from 'remark-gfm';
 import mermaid from 'mermaid';
 import { useEffect, useRef } from 'react';
 
-mermaid.initialize({ startOnLoad: true });
+// Detect Tailwind's dark mode class to adjust Mermaid theme for better contrast
+const mermaidTheme =
+  typeof document !== 'undefined' &&
+  document.documentElement.classList.contains('dark')
+    ? 'dark'
+    : 'default';
+mermaid.initialize({ startOnLoad: true, theme: mermaidTheme });
 
 export default function MarkdownRenderer({ children, components = {} }) {
   const containerRef = useRef(null);


### PR DESCRIPTION
## Summary
- set mermaid theme to match Tailwind dark mode to improve arrow visibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6863c6f98b60832684eb7541ea917dc3