### PR TITLE
Fix mermaid sequence arrow visibility

### DIFF
--- a/src/front_end/src/index.css
+++ b/src/front_end/src/index.css
@@ -19,4 +19,13 @@
   .mermaid svg text {
     fill: currentColor !important;
   }
+  /* Ensure diagram lines and arrowheads remain visible */
+  .mermaid svg line,
+  .mermaid svg path,
+  .mermaid svg polygon {
+    stroke: currentColor !important;
+  }
+  .mermaid svg polygon {
+    fill: currentColor !important;
+  }
 }


### PR DESCRIPTION
## Summary
- ensure mermaid lines and arrowheads inherit current text color

## Testing
- `npm install` *(fails: 3 moderate vulnerabilities)*
- `pytest` *(fails to collect tests: ImportError: cannot import name 'model_validator' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6863d449bb588326a00bde3f863e85e9